### PR TITLE
Fix for issue #1792

### DIFF
--- a/content/kapacitor/v1.5/event_handlers/email.md
+++ b/content/kapacitor/v1.5/event_handlers/email.md
@@ -115,7 +115,7 @@ _**SMTP settings in kapacitor.conf**_
   username = "username"
   password = "passw0rd"
   from = "me@emyserver.com"
-  to = "oncall0@mydomain.com"
+  to = ["oncall0@mydomain.com"]
   no-verify = false
   idle-timeout = "30s"
   global = false


### PR DESCRIPTION
Fix the typo in documentation of SMTP settings in kapacitor.conf of the "to" value that allows starting the service when using the example configuration. 